### PR TITLE
(fix) make Camera work over HTTPS

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,7 @@
   <meta charset="utf-8"/>
   <title>D7-Do something every single day</title>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
 
 </head>
 <body>


### PR DESCRIPTION
resolve #87 
localtunnel that we have tested on connects on HTTPS, which cannot get jQuery CDN files over HTTP